### PR TITLE
Fixed JsonBodyParser ContentType "application/json;charset=utf-8"

### DIFF
--- a/src/Phluid/Middleware/JsonBodyParser.php
+++ b/src/Phluid/Middleware/JsonBodyParser.php
@@ -16,7 +16,7 @@ class JsonBodyParser {
   
   //Just JSON
   function __invoke( $request, $response, $next ){
-    if ( $request->getContentType() == 'application/json' || explode(";", $request->getContentType())[0] == 'application/json') {
+    if ( strpos($request->getHeader('Content-Type'),'application/json')===0 ){
       $body = "";
       $request->on( 'data', function( $data ) use ( &$body ){
         $body .= $data;

--- a/src/Phluid/Middleware/JsonBodyParser.php
+++ b/src/Phluid/Middleware/JsonBodyParser.php
@@ -16,7 +16,7 @@ class JsonBodyParser {
   
   //Just JSON
   function __invoke( $request, $response, $next ){
-    if ( $request->getContentType() == 'application/json' ) {
+    if ( $request->getContentType() == 'application/json' || explode(";", $request->getContentType())[0] == 'application/json') {
       $body = "";
       $request->on( 'data', function( $data ) use ( &$body ){
         $body .= $data;


### PR DESCRIPTION
While working with Phluid as my backend and axios as my front-end HTTP client, I came across a problem where Phuild wouldn't accept my `post` request which had valid JSON as the body. The error was because the `Content-Type` wasn't strictly `application/json`. I'm guessing axios adds `charset=utf-8` by default.

By the way, thanks for this wonderful library 😄 !